### PR TITLE
Building sds-server binary in container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,14 +18,10 @@ clean:
 	rm ${OUT}
 # Please make sure that user has enough privilege to execute docker command
 docker: 
-	LIBRARY_PATH=/usr/local/lib go build -o ${BINARY} main.go
 	docker build -t ${HUB}/${BINARY}:${TAG} .
-	rm ${BINARY}
 
 ctr: 
-	LIBRARY_PATH=/usr/local/lib go build -o ${BINARY} main.go
 	docker build -t ${HUB}/${BINARY}:${TAG} .
-	rm ${BINARY}
 	docker save -o ${BINARY}.tar ${HUB}/${BINARY}:${TAG}
 	ctr -n k8s.io image import ${BINARY}.tar
 	rm ${BINARY}.tar


### PR DESCRIPTION
I found that our previous build method may encounter `libc` incompatibility problems in systems other than ubuntu20.04 (Sinece we build on the host and run in the container). So transfer all the compilation to the docker build process to avoid such problems.